### PR TITLE
Add makefile support for cloning and building sta-rs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,11 @@
 binary = star-randsrv
 image = $(binary):latest
 godeps = *.go go.mod go.sum
+stardeps = sta-rs sta-rs/ppoprf/ffi/include/ppoprf.h sta-rs/target/release/libffi.a
 
 all: test lint $(binary)
 
-test: $(godeps)
+test: $(godeps) $(stardeps)
 	go test -cover ./...
 
 lint:
@@ -41,8 +42,14 @@ docker:
 	@rm -f $(binary)-repro.tar
 	@echo $(image)
 
-$(binary): $(godeps)
+$(binary): $(godeps) $(stardeps)
 	go build -o $(binary)
+
+sta-rs:
+	git clone --branch ppoprf-ffi https://github.com/NullHypothesis/sta-rs
+
+sta-rs/ppoprf/ffi/include/ppoprf.h sta-rs/target/release/libffi.a:
+	cd sta-rs/ppoprf/ffi && cargo build --release
 
 clean:
 	@rm -f $(binary)

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 /*
 #cgo LDFLAGS: -L sta-rs/target/release -lffi -lpthread -ldl -static
-#cgo CFLAGS: -I include -O3
+#cgo CFLAGS: -I sta-rs/ppoprf/ffi/include -O3
 #include "sta-rs/ppoprf/ffi/include/ppoprf.h"
 */
 import "C"


### PR DESCRIPTION
The randomness server depends on an ffi wrapper around the ppoprf
implementation in the sta-rs repo. Download and build the current
branch to make things work with less fiddling.