### PR TITLE
Add github actions build and test description.

### DIFF
--- a/.github/workflows/makefile.yaml
+++ b/.github/workflows/makefile.yaml
@@ -1,0 +1,32 @@
+name: Makefile
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+  pull_request:
+    branches:
+     - main
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.17
+
+    - name: Install golangci-lint
+      run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
+
+    - name: Build
+      run: make

--- a/.github/workflows/makefile.yaml
+++ b/.github/workflows/makefile.yaml
@@ -14,7 +14,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  make:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout


### PR DESCRIPTION
Gives us some feedback on the state of the repository and proposed
changes. This invokes the default `make` target.

It specifies go and golangci-lint versions, but uses github's
default rust toolchain.