### PR TITLE
Disable debug by default.

### DIFF
--- a/main.go
+++ b/main.go
@@ -171,7 +171,7 @@ func main() {
 			SOCKSProxy: "socks5://127.0.0.1:1080",
 			FQDN:       "nitro.nymity.ch",
 			Port:       8080,
-			Debug:      true,
+			Debug:      false,
 			UseACME:    false,
 		},
 	)


### PR DESCRIPTION
We prefer the have debug off by default on the main branch because
it adds a lot of overhead. While logging is nice, the enclave won't
perform well, and it's less obvious how to address that issue.

Follow up to https://github.com/brave-experiments/star-randsrv/pull/6