### PR TITLE
Enable automated, reproducible builds.

### DIFF
--- a/.github/workflows/generalized-deployments-reproducible.yaml
+++ b/.github/workflows/generalized-deployments-reproducible.yaml
@@ -1,0 +1,23 @@
+on: push
+
+name: Generalized Reproducible Deployments
+jobs:
+  push:
+    name: Invoke General Reproducible Docker Build Pipeline
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.GDBP_AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.GDBP_AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-west-2
+    - name: Override GITHUB_REF and thus ECR destination for master
+      run: echo "GITHUB_REF_OVERRIDE=refs/heads/dev" >> $GITHUB_ENV
+      if: ${{ github.ref == 'refs/heads/master' }}
+    - name: Set REPRODUCIBLE to get a reproducible build
+      run: echo "REPRODUCIBLE=true" >> $GITHUB_ENV
+    - name: Generalized Deployments
+      uses: brave-intl/general-docker-build-pipeline-action@v1.0.9

--- a/.github/workflows/generalized-deployments-reproducible.yaml
+++ b/.github/workflows/generalized-deployments-reproducible.yaml
@@ -1,4 +1,9 @@
-on: push
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
 
 name: Generalized Reproducible Deployments
 jobs:

--- a/.github/workflows/generalized-deployments-reproducible.yaml
+++ b/.github/workflows/generalized-deployments-reproducible.yaml
@@ -19,9 +19,9 @@ jobs:
         aws-access-key-id: ${{ secrets.GDBP_AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.GDBP_AWS_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
-    - name: Override GITHUB_REF and thus ECR destination for master
+    - name: Override GITHUB_REF and thus ECR destination for main
       run: echo "GITHUB_REF_OVERRIDE=refs/heads/dev" >> $GITHUB_ENV
-      if: ${{ github.ref == 'refs/heads/master' }}
+      if: ${{ github.ref == 'refs/heads/main' }}
     - name: Set REPRODUCIBLE to get a reproducible build
       run: echo "REPRODUCIBLE=true" >> $GITHUB_ENV
     - name: Generalized Deployments


### PR DESCRIPTION
This commit adds a GitHub action that automatically triggers reproducible Docker image builds when we push to the repository. The Docker images end up in our AWS image registry, allowing us to fetch them as part of our enclave bootstrapping process.