### PR TITLE
Silence a warning.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ mod tests {
         let point = CompressedRistretto::default();
         let mut result = Vec::with_capacity(ppoprf::COMPRESSED_POINT_LEN);
         unsafe {
-            let eval_res = randomness_server_eval(
+            let _eval_res = randomness_server_eval(
                 server,
                 point.as_bytes().as_ptr(),
                 50,


### PR DESCRIPTION
We don't actually verify the randomness server's proof in the
unit test, so make the compiler happy by marking the result
as unused until we address the fixme.

Follow-up to #21 review comment.