### PR TITLE
Include CA certificates in image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN go build -trimpath -o star-randsrv ./
 # Copy from the builder to keep the final image reproducible and small.  If we
 # don't do this, we end up with non-deterministic build artifacts.
 FROM scratch
+COPY --from=go-builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=go-builder /src/star-randsrv /
 EXPOSE 8443
 CMD ["/star-randsrv"]


### PR DESCRIPTION
When run in Kubernetes, star-randsrv was unable to get a certificate
from Let's Encrypt because it considered its endpoint to be signed by an
unknown authority.  This patch adds root certificates to the final
star-randsrv image.

This fixes https://github.com/brave-experiments/star-randsrv/issues/25.

One thing worth considering: We don't need an entire root CA store. We
only need Let's Encrypt's chain of trust. We could hard-code that in the
randomness server, which makes us less vulnerable to CA compromise at
the cost of some additional maintenance burden.