### PR TITLE
Set content type before sending response.

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,6 +51,9 @@ const (
 	serializedPkBufferSize uint = 10240
 	// The last epoch, before our counter overflows
 	maxEpoch = ^epoch(0)
+	// HTTP header keys and values.
+	httpContentType = "Content-Type"
+	contentTypeJSON = "application/json"
 )
 
 type epoch uint8
@@ -251,6 +254,7 @@ func getServerInfo(srv *Server) http.HandlerFunc {
 			NextEpochTime: nextEpochTime.Format(time.RFC3339),
 		}
 		srv.Unlock()
+		w.Header().Set(httpContentType, contentTypeJSON)
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -320,6 +324,7 @@ func getRandomnessHandler(srv *Server) http.HandlerFunc {
 			resp.Epoch = req.Epoch
 		}
 
+		w.Header().Set(httpContentType, contentTypeJSON)
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/main_test.go
+++ b/main_test.go
@@ -130,7 +130,7 @@ func TestInfoContentType(t *testing.T) {
 
 func TestRandomnessContentType(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/randomness", strings.NewReader(validPayload))
-	handler := getServerInfo(srvWithEpochLen(defaultEpochLen))
+	handler := getRandomnessHandler(srvWithEpochLen(defaultEpochLen))
 
 	rec := httptest.NewRecorder()
 	handler(rec, req)


### PR DESCRIPTION
For some reason, when run in Kubernetes, the randomness server responds
with an incorrect content type:

    content-type: application/vnd.ms-fontobject

This patch teaches the randomness server to respond with the correct
content type:

    Content-Type: application/json