### PR TITLE
Add tests for default epoch selection

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -35,7 +35,7 @@ func srvWithEpochLen(epochLen time.Duration) *Server {
 	return srv
 }
 
-// Pass a request to to given hander and return the status and response body.
+// Pass a request to the given handler and return the status and response body.
 func makeReq(handler http.HandlerFunc, req *http.Request) (int, string) {
 	rec := httptest.NewRecorder()
 	handler(rec, req)

--- a/main_test.go
+++ b/main_test.go
@@ -55,7 +55,7 @@ func makeInfoReq(srv *Server) srvInfoResponse {
 	handler := getServerInfo(srv)
 
 	var res srvInfoResponse
-	req := httptest.NewRequest(http.MethodPost, "/info", nil)
+	req := httptest.NewRequest(http.MethodGet, "/info", nil)
 	status, result := makeReq(handler, req)
 	if status != http.StatusOK {
 		log.Fatalf("Expected HTTP code %d but got %d.", http.StatusOK, status)


### PR DESCRIPTION
- Verify `getRandomnessHandler` applies the current epoch if none is specified in the client.
- Verify an epoch in the requested epoch is returned in the response.

Uses variadic args in `makeRandomnessReq(...)` as a substitute for optional arguments so it can build the request with or without the `epoch` property.
