### PR TITLE
Switch to non-privileged user before execution.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,6 @@ FROM scratch
 COPY --from=go-builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=go-builder /src/star-randsrv /
 EXPOSE 8443
+# Switch to the UID that's typically reserved for the user "nobody".
+USER 65534
 CMD ["/star-randsrv"]

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/brave-experiments/star-randsrv
 go 1.19
 
 require (
-	github.com/brave/nitriding v1.1.1
+	github.com/brave/nitriding v1.1.2
 	github.com/bwesterb/go-ristretto v1.2.2
 )
 
@@ -18,9 +18,9 @@ require (
 	github.com/mdlayher/vsock v1.1.1 // indirect
 	github.com/milosgajdos/tenus v0.0.3 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
-	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa // indirect
+	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 // indirect
 	golang.org/x/net v0.0.0-20220812174116-3211cb980234 // indirect
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
-	golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab // indirect
+	golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64 // indirect
 	golang.org/x/text v0.3.7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/brave/nitriding v1.1.1 h1:bmDD9KYypKTlMMicc6reO+A5tMSVaEe6BXKVmUAO+xk=
 github.com/brave/nitriding v1.1.1/go.mod h1:iC6ilXBejshu3zA6O5uALAFk1x5lRvhMEBO6NN+gdxc=
+github.com/brave/nitriding v1.1.2 h1:l7MMOLkXW8ANPPer9A9rmyGDOtDYNxhGguFPaEjto2E=
+github.com/brave/nitriding v1.1.2/go.mod h1:yCcJb7Ezdmop4mHiOMUpYUMPWDKZXfkzEu4XTNRIMBU=
 github.com/brave/viproxy v0.1.2 h1:sOY8bI1CqLNq+KyRJrEzQuWia81UmLjK5kqTqD284hs=
 github.com/brave/viproxy v0.1.2/go.mod h1:E5v9Ajo1sPVAmgDjKDU8fLmkoJeHjtcXJIkEm8XubpQ=
 github.com/bwesterb/go-ristretto v1.2.2 h1:S2C0mmSjCLS3H9+zfXoIoKzl+cOncvBvt6pE+zTm5Ms=
@@ -30,6 +32,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa h1:zuSxTR4o9y82ebqCUJYNGJbGPo6sKVl54f/TVDObg1c=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 h1:Y/gsMcFOcR+6S6f3YeMKl5g+dZMEWqcz5Czj/GWYbkM=
+golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -47,6 +51,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab h1:2QkjZIsXupsJbJIdSjjUOgWK3aEtzyuh2mPt3l/CkeU=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64 h1:UiNENfZ8gDvpiWw7IpOMQ27spWmThO1RwwdQVbJahJM=
+golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=

--- a/main.go
+++ b/main.go
@@ -341,6 +341,7 @@ func getRandomnessHandler(srv *Server) http.HandlerFunc {
 }
 
 func main() {
+	elog.Printf("Running as UID %d.", os.Getuid())
 	firstEpochTime, epochLen := getFirstEpochTimeAndLen()
 	srv, err := NewServer(firstEpochTime, epochLen)
 	if err != nil {


### PR DESCRIPTION
For this to work, we need to upgrade to nitriding v1.1.2 because it disables the certificate cache when inside an enclave.  When outside an enclave, we can use a Docker volume to map the certificate cache into the image, e.g.:

    docker run -v cert-cache:/cert-cache star-randsrv:latest

This fixes https://github.com/brave-experiments/star-randsrv/issues/31.