### PR TITLE
Run `go vet` as part of the lint suite.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ test: $(godeps) $(stardeps)
 
 lint:
 	golangci-lint run ./...
+	go vet
 	cargo clippy
 	cargo audit
 


### PR DESCRIPTION
We mark the Server struct as `noCopy` to detect problems with deallocation on the wrong side of the FFI bridge, but need to run the `vet` tool to report them. This ensures we check this lint in default and ci builds.