### PR TITLE
Limit the number of points that the server is willing to process.

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,6 +75,7 @@ type srvInfoResponse struct {
 	PublicKey     string `json:"publicKey"`
 	CurrentEpoch  epoch  `json:"currentEpoch"`
 	NextEpochTime string `json:"nextEpochTime"`
+	MaxPoints     int    `json:"maxPoints"`
 }
 
 // Embed an zero-length struct to mark our wrapped structs `noCopy`
@@ -256,6 +257,7 @@ func getServerInfo(srv *Server) http.HandlerFunc {
 			PublicKey:     srv.pubKey,
 			CurrentEpoch:  currentEpoch,
 			NextEpochTime: nextEpochTime.Format(time.RFC3339),
+			MaxPoints:     maxPoints,
 		}
 		srv.Unlock()
 		w.Header().Set(httpContentType, contentTypeJSON)

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -38,6 +39,7 @@ var (
 	errDecodeECPoint  = "failed to decode EC point"
 	errParseECPoint   = "failed to parse EC point"
 	errEpochExhausted = "epochs are exhausted"
+	errTooManyPoints  = fmt.Sprintf("too many points (> %d) given", maxPoints)
 
 	defaultFirstEpochTime, _ = time.Parse(time.RFC3339, "2022-01-01T00:00:00.000Z")
 )
@@ -51,6 +53,8 @@ const (
 	serializedPkBufferSize uint = 10240
 	// The last epoch, before our counter overflows
 	maxEpoch = ^epoch(0)
+	// The maximum number of points we're willing to process
+	maxPoints = 1000
 	// HTTP header keys and values.
 	httpContentType = "Content-Type"
 	contentTypeJSON = "application/json"
@@ -287,6 +291,10 @@ func getRandomnessHandler(srv *Server) http.HandlerFunc {
 		}
 		if len(req.Points) == 0 {
 			http.Error(w, errNoECPoints, http.StatusBadRequest)
+			return
+		}
+		if len(req.Points) > maxPoints {
+			http.Error(w, errTooManyPoints, http.StatusBadRequest)
 			return
 		}
 		if req.Epoch == nil {

--- a/main_test.go
+++ b/main_test.go
@@ -191,6 +191,17 @@ func TestRandomnessContentType(t *testing.T) {
 	}
 }
 
+func TestPointLimitInInfo(t *testing.T) {
+	srv := srvWithEpochLen(defaultEpochLen)
+	infoResp := makeInfoReq(srv)
+
+	// Make sure that the handler returns the maximum number of points that the
+	// server is willing to process.
+	if infoResp.MaxPoints != maxPoints {
+		t.Fatalf("Expected point limit of %d but got %d.", maxPoints, infoResp.MaxPoints)
+	}
+}
+
 func TestRandomnessEpoch(t *testing.T) {
 	srv := srvWithEpochLen(defaultEpochLen)
 

--- a/main_test.go
+++ b/main_test.go
@@ -261,6 +261,31 @@ func TestHTTPHandler(t *testing.T) {
 		t.Errorf("Expected HTTP code %d but got %d.", http.StatusBadRequest, code)
 	}
 
+	// Provide no points.
+	badReq = httptest.NewRequest(http.MethodPost, "/randomness", strings.NewReader(`{"points":[]}`))
+	code, resp = makeReq(handler, badReq)
+	if resp != errNoECPoints {
+		t.Errorf("Expected %q but got %q.", errNoECPoints, resp)
+	}
+	if code != http.StatusBadRequest {
+		t.Errorf("Expected HTTP code %d but got %d.", http.StatusBadRequest, code)
+	}
+
+	// Provide too many points.
+	j := `{"points":[`
+	for i := 0; i < maxPoints; i++ {
+		j += fmt.Sprintf("\"%s\",", validPoint)
+	}
+	j += fmt.Sprintf("\"%s\"]}", validPoint)
+	badReq = httptest.NewRequest(http.MethodPost, "/randomness", strings.NewReader(j))
+	code, resp = makeReq(handler, badReq)
+	if resp != errTooManyPoints {
+		t.Errorf("Expected %q but got %q.", errTooManyPoints, resp)
+	}
+	if code != http.StatusBadRequest {
+		t.Errorf("Expected HTTP code %d but got %d.", http.StatusBadRequest, code)
+	}
+
 	// Provide an invalid EC point.
 	badPayload := `{"points":["1111111111111111111111111111111111111111111111111111111111111111"]}`
 	badReq = httptest.NewRequest(http.MethodPost, "/randomness", strings.NewReader(badPayload))


### PR DESCRIPTION
This PR makes two changes:

1. Limit the maximum number of EC points that the server is willing to process.
2. Return this point limit in the response of the `/info` handler.

The code uses a semi-arbitrary limit of 1,000 points which should be large enough to be reasonably future-proof while being small enough to not enable computational DoS attacks.